### PR TITLE
nashorn running react isn't thread safe

### DIFF
--- a/src/main/kotlin/griffio/web/WebApplication.kt
+++ b/src/main/kotlin/griffio/web/WebApplication.kt
@@ -41,6 +41,7 @@ open class WebApplication : WebMvcConfigurerAdapter() {
                 "/babel.min.js",
                 "/create-react-class.min.js",
                 "/react-templating.js")
+        configurer.setSharedEngine(false)
         configurer.renderFunction = "renderJsx"
         return configurer
     }

--- a/src/main/resources/react-templating.js
+++ b/src/main/resources/react-templating.js
@@ -22,6 +22,5 @@ function render(template, model) {
 
 function renderJsx(template, model) {
     var jsTemplate = Babel.transform(template, { presets: ['react'] }).code;
-    console.log(jsTemplate);
     return render(jsTemplate, model);
 }


### PR DESCRIPTION
Using apache bench there are issues running with concurrency greater than 1, e.g. 

`ab -n 5000 -c 5 http://localhost:8080/comments.html`

Will generate a lot of errors that don't happen with `-c 1`. Reading the docs for `ScriptTemplateConfigurer` it mentions:

> It is possible to use non thread-safe script engines with templating libraries not designed for concurrency, like Handlebars or React running on Nashorn, by setting the sharedEngine property to false.

Setting that property stops the errors. The docs for that property state:

> When set to false, use thread-local ScriptEngine instances instead of one single shared instance.

This matches the fix to a similar problem on a different nashorn demo over at https://github.com/winterbe/spring-react-example/issues/3
